### PR TITLE
Update perlanetrc - fixed existing feed & adding a blog feed

### DIFF
--- a/perlanetrc
+++ b/perlanetrc
@@ -63,9 +63,9 @@ feeds:
   - feed: https://metacpan.org/feed/news
     title: MetaCPAN News
     web: https://metacpan.org/news
-  - feed: https://nxadm.wordpress.com/tag/perl/feed
+  - feed: https://nxadm.apt-get.be/tags/perl/index.xml
     title: nxadm
-    web: https://nxadm.wordpress.com/tag/perl/
+    web: https://nxadm.apt-get.be/tags/perl/
   - feed: https://theweeklychallenge.org/blog/index.xml
     title: The Weekly Challenge
     web: https://theweeklychallenge.org/blog/
@@ -87,5 +87,8 @@ feeds:
   - feed: https://www.youtube.com/feeds/videos.xml?channel_id=UC7y4qaRSb5w2O8cCHOsKZDw
     title: The Perl and Raku Conference YouTube channel
     web: https://www.youtube.com/@YAPCNA
+  - feed: https://github.polettix.it/ETOOBUSY/feed.xml
+    title: Personal blog of Flavio Poletti (Perl & Raku)
+    web: https://github.polettix.it/ETOOBUSY/
 
 # ex: ft=yaml:


### PR DESCRIPTION
Hi! This is a great feed for someone like myself trying to dig more into Perl, so thanks for building this.

A couple of things in this PR:

- Fixing nxadm blog, since they moved from their wordpress to https://nxadm.apt-get.be (I kept it filtering for posts with the "perl" tag)
- Adding https://github.polettix.it/ETOOBUSY/ - an excellent mostly-Perl-centric blog. I couldn't seem to find a way to filter for Perl tag with the feed link, but it seems like that tag is not encompassing a lot of posts pertaining to Perl stuff anyways. 

It would be understandable if there is a determination that the second item should not be added, but I find myself going back to that blog a lot so I figured I would put it in here.

Regards,
_Rooney_