### PR TITLE
Fix behaviour of 'all feeds' toggle

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -84,11 +84,19 @@ $(document).ready(function() {
     }
   });
 
+  // Set the "All Feeds" checkbox to checked when the page loads
+  $('#all-feeds').prop('checked', true);
+
   // Add event listener for "All Feeds" checkbox
   $('#all-feeds').click(function() {
     var isChecked = $(this).prop('checked');
     $('.feed-checkbox').each(function() {
-      $(this).prop('checked', isChecked).trigger('click');
+      $(this).prop('checked', isChecked);
+      if (isChecked) {
+        $('.' + $(this).attr('id')).show();
+      } else {
+        $('.' + $(this).attr('id')).hide();
+      }
     });
   });
 
@@ -157,4 +165,3 @@ function getCookie(cname) {
     }
     return "";
 }
-

--- a/index.tt
+++ b/index.tt
@@ -74,7 +74,7 @@
           <hr class="hr" />
           <h2>Sources</h2>
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="all-feeds">
+            <input class="form-check-input" type="checkbox" id="all-feeds" checked>
             <label class="form-check-label" for="all-feeds">
               All Feeds
             </label><br>


### PR DESCRIPTION
Fixes #55

Update the "All Feeds" checkbox behavior to be checked by default and modify its event handler.

* Set the "All Feeds" checkbox to checked when the page loads in `docs/script.js`.
* Update the click event handler for the "All Feeds" checkbox in `docs/script.js` to show or hide feeds without triggering the click event for each feed checkbox.
* Render the "All Feeds" checkbox as checked by default in `index.tt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/planetperl/pull/56?shareId=339e05b1-6888-4dc9-a393-7a125be4185c).