### PR TITLE
Make the 'all feeds' checkbox affect local storage

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -84,12 +84,25 @@ $(document).ready(function() {
     }
   });
 
-  // Set the "All Feeds" checkbox to checked when the page loads
-  $('#all-feeds').prop('checked', true);
+  // Check localStorage for the "all-feeds" key value on page load
+  var allFeedsValue = localStorage.getItem('all-feeds');
+  if (allFeedsValue === "true") {
+    $('#all-feeds').prop('checked', true);
+  } else if (allFeedsValue === "false") {
+    $('#all-feeds').prop('checked', false);
+    checkboxes.each(function() {
+      $(this).prop('checked', false);
+      $('.' + $(this).attr('id')).hide();
+    });
+  } else {
+    localStorage.setItem('all-feeds', "true");
+    $('#all-feeds').prop('checked', true);
+  }
 
   // Add event listener for "All Feeds" checkbox
   $('#all-feeds').click(function() {
     var isChecked = $(this).prop('checked');
+    localStorage.setItem('all-feeds', isChecked);
     $('.feed-checkbox').each(function() {
       $(this).prop('checked', isChecked);
       if (isChecked) {


### PR DESCRIPTION
Fixes #58

Add functionality to update and check the "all-feeds" key in local storage.

* Add code to update the "all-feeds" key in local storage when the "all feeds" checkbox is clicked.
* Add code to check local storage for the "all-feeds" key value on page load and set the "all feeds" checkbox accordingly.
* Add code to use the "all-feeds" key in local storage to determine the display of individual feeds on page load.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PerlToolsTeam/planetperl/pull/59?shareId=be79c805-e318-4cae-87f9-b451dcd53296).